### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/tools/ncp2222.py
+++ b/tools/ncp2222.py
@@ -521,6 +521,19 @@ class NCP:
 		lower = min_hdr_length
 		upper = min_hdr_length
 
+		def is_sensitive_field(record):
+			# Try to detect if the field is sensitive (e.g., password)
+			field = record[REC_FIELD]
+			# Check if the field has a name or description containing 'password'
+			name = getattr(field, 'name', '')
+			desc = getattr(field, 'desc', '')
+			if (isinstance(name, str) and 'password' in name.lower()) or \
+			   (isinstance(desc, str) and 'password' in desc.lower()):
+				return True
+			return False
+
+		contains_sensitive = any(is_sensitive_field(record) for record in records)
+
 		for record in records:
 			rec_size = record[REC_LENGTH]
 			rec_lower = rec_size
@@ -534,12 +547,20 @@ class NCP:
 
 		error = 0
 		if min != lower:
-			msg.write("%s records for 2222/0x%x sum to %d bytes minimum, but param1 shows %d\n" \
-				% (descr, self.FunctionCode(), lower, min))
+			if contains_sensitive:
+				msg.write("%s records for 2222/0x%x include sensitive fields; details redacted.\n" \
+					% (descr, self.FunctionCode()))
+			else:
+				msg.write("%s records for 2222/0x%x sum to %d bytes minimum, but param1 shows %d\n" \
+					% (descr, self.FunctionCode(), lower, min))
 			error = 1
 		if max != upper:
-			msg.write("%s records for 2222/0x%x sum to %d bytes maximum, but param1 shows %d\n" \
-				% (descr, self.FunctionCode(), upper, max))
+			if contains_sensitive:
+				msg.write("%s records for 2222/0x%x include sensitive fields; details redacted.\n" \
+					% (descr, self.FunctionCode()))
+			else:
+				msg.write("%s records for 2222/0x%x sum to %d bytes maximum, but param1 shows %d\n" \
+					% (descr, self.FunctionCode(), upper, max))
 			error = 1
 
 		if error == 1:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/10](https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/10)

To fix the problem, we should ensure that log messages do not include information about sensitive fields such as passwords. In the `CheckRecords` method, when logging errors about record sizes, we should check if any of the records being processed correspond to sensitive fields (e.g., those named "password" or similar). If so, we should either redact the field name from the log message or avoid logging the message altogether. The best way to implement this is to add a check in the `CheckRecords` method to detect if any record's field is a password (by checking its name or description), and then modify the log message to avoid mentioning sensitive fields.

This requires:
- Adding a helper function to detect if a record is sensitive (e.g., if its field name or description contains "password").
- Modifying the log message in `CheckRecords` to redact or suppress information about sensitive fields.

All changes are to be made in `tools/ncp2222.py`, specifically in the `CheckRecords` method and possibly by adding a helper function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
