### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/tools/ncp2222.py
+++ b/tools/ncp2222.py
@@ -235,8 +235,16 @@ class PTVC(NamedList):
 				pass
 
 			elif expected_offset != offset and offset != -1:
+				# Redact sensitive field names in log messages
+				def is_sensitive_field(field_name):
+				    # Add more sensitive field names as needed
+				    sensitive_names = {"New Password", "Password", "new_password", "password"}
+				    return field_name in sensitive_names
+				field_name = field.HFName()
+				if is_sensitive_field(field_name):
+				    field_name = "[REDACTED]"
 				msg.write("Expected offset in %s for %s to be %d\n" % \
-					(name, field.HFName(), expected_offset))
+					(name, field_name, expected_offset))
 				sys.exit(1)
 
 			# We can't make a PTVC list from a variable-length


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/8](https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/8)

To fix the problem, we should avoid logging sensitive field names such as "New Password" in the log message. The best way to do this is to redact or mask the field name if it matches a known sensitive identifier, or to replace it with a generic placeholder (e.g., "[REDACTED]"). This can be done by checking the field name before logging and substituting it if necessary. The change should be made in the block where the log message is constructed (line 238), within the PTVC class's `__init__` method. We will need to add a helper function to determine if a field name is sensitive, and use it to conditionally redact the field name in the log message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
