### PR TITLE
Potential fix for code scanning alert no. 15: Clear-text storage of sensitive information

### DIFF
--- a/tools/ncp2222.py
+++ b/tools/ncp2222.py
@@ -237,9 +237,9 @@ class PTVC(NamedList):
 			elif expected_offset != offset and offset != -1:
 				# Redact sensitive field names in log messages
 				def is_sensitive_field(field_name):
-				    # Add more sensitive field names as needed
-				    sensitive_names = {"New Password", "Password", "new_password", "password"}
-				    return field_name in sensitive_names
+				    # Case-insensitive check for sensitive field names
+				    sensitive_keywords = ["password", "new password"]
+				    return any(kw in field_name.lower() for kw in sensitive_keywords)
 				field_name = field.HFName()
 				if is_sensitive_field(field_name):
 				    field_name = "[REDACTED]"


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/15](https://github.com/Git-Hub-Chris/WiresharkFoundation/security/code-scanning/15)

To fix the problem, we should ensure that no sensitive field names are ever logged in clear text. The current code attempts to redact certain field names before logging, but this approach relies on maintaining a list of sensitive names and could be error-prone if new sensitive fields are added in the future. The best way to address this is to generalize the redaction logic and ensure that any field name matching a sensitive pattern is always redacted before logging. This can be done by expanding the list of sensitive field names and/or using a case-insensitive comparison. Additionally, we should consider logging only non-sensitive information, or omitting the field name entirely if it is sensitive.

The required changes are in the block of code around line 238-246, where the logging occurs. We should update the `is_sensitive_field` function to perform a case-insensitive check and include common variations of sensitive field names. We should also ensure that the redaction is applied consistently. No new imports are needed, as the code only needs basic string operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
